### PR TITLE
Ignore non-JS files in destinationDir

### DIFF
--- a/index.js
+++ b/index.js
@@ -218,7 +218,9 @@ function fastifyView (fastify, opts, next) {
 
     // .jst files are compiled to .js files so we need to require them
     for (const file of readdirSync(destinationDir, { withFileTypes: false })) {
-      renderer[basename(file, '.js')] = require(resolve(join(destinationDir, file)))
+      if (file.match(/\.js$/i)) {
+        renderer[basename(file, '.js')] = require(resolve(join(destinationDir, file)))
+      }
     }
     if (Object.keys(renderer).length === 0) {
       this.log.warn(`WARN: no template found in ${templatesDir}`)


### PR DESCRIPTION
Some operating systems silently and automatically create "hidden files" inside new directories. So, for example on Mac OS, the destinationDir can have a `.DS_Store` file appear within it from the system. The code in point-of-view that tries to `require` compiled templates should ignore these, and indeed any files that do not end in `.js`.